### PR TITLE
Frontend "wp_viewport for this surface already exists" crash on sway fix

### DIFF
--- a/src/frontend/frontend_state.rs
+++ b/src/frontend/frontend_state.rs
@@ -10,7 +10,7 @@ use wayland_protocols_wlr::{
 use wayland_protocols::{
     wp::{
         single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1,
-        viewporter::client::wp_viewporter,
+        viewporter::client::{wp_viewporter, wp_viewport},
     },
 };
 
@@ -38,6 +38,8 @@ pub struct State {
     pub update_surface: Option<wl_surface::WlSurface>,
     pub update_layer_surface: Option<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1>,
     pub update_frame_callback: Option<wl_callback::WlCallback>,
+    pub capture_viewport: Option<wp_viewport::WpViewport>,
+    pub update_viewport: Option<wp_viewport::WpViewport>,
     pub clipboard_history: Vec<ClipboardItemPreview>,
 }
 
@@ -65,6 +67,8 @@ impl State {
             update_surface: None,
             update_layer_surface: None,
             update_frame_callback: None,
+            capture_viewport: None,
+            update_viewport: None,
             clipboard_history: Vec::new(),
         }
     }


### PR DESCRIPTION
!VIBE CODE!

I really like the concept of this program, but it crashes on my system (CachyOS + Sway) for some reason with this message:

[INFO  cursor_clip] Starting clipboard frontend...
Protocol error 0 on object wp_viewporter@6: wp_viewport for this surface already exists
Error: Backend(Protocol(ProtocolError { code: 0, object_id: 6, object_interface: "wp_viewporter", message: "wp_viewport for this surface already exists" }))

Since I thought it would be hard to reproduce, I just asked AI to fix it. And fix it, it did. It works perfectly on my system now, but since I don’t know Rust or Wayland, I can’t tell whether the code is actually any good.

I’m submitting this instead of opening an issue so you can take a look at what the AI changed and maybe implement a proper fix.