### PR TITLE
feat: Implement Ext Data Control Protocol support

### DIFF
--- a/src/backend/backend_state.rs
+++ b/src/backend/backend_state.rs
@@ -1,28 +1,28 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::collections::HashMap;
-use std::io::Cursor;
+use crate::backend::wayland_clipboard::MutexBackendState; // for QueueHandle type
 use fast_image_resize as fir;
 use fast_image_resize::images::Image;
 use image::{ImageFormat, RgbaImage};
-use wayland_client::backend::ObjectId;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::time::{SystemTime, UNIX_EPOCH};
 use wayland_client::Proxy;
+use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_seat;
+use wayland_client::{Connection, QueueHandle};
 use wayland_protocols::ext::data_control::v1::client::{
     ext_data_control_device_v1::ExtDataControlDeviceV1,
     ext_data_control_manager_v1::ExtDataControlManagerV1,
     ext_data_control_source_v1::ExtDataControlSourceV1,
 };
 use wayland_protocols_wlr::data_control::v1::client::{
-    zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
     zwlr_data_control_device_v1::ZwlrDataControlDeviceV1,
+    zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
     zwlr_data_control_source_v1::ZwlrDataControlSourceV1,
 };
-use crate::backend::wayland_clipboard::MutexBackendState; // for QueueHandle type
-use wayland_client::{QueueHandle, Connection};
 
-use crate::shared::{ClipboardItem, ClipboardItemPreview, ClipboardContentType};
-use indexmap::IndexMap;
+use crate::shared::{ClipboardContentType, ClipboardItem, ClipboardItemPreview};
 use bytes::Bytes;
+use indexmap::IndexMap;
 use log::{debug, info, warn};
 
 #[derive(Debug, Clone)]
@@ -58,7 +58,11 @@ impl DataControlManager {
         }
     }
 
-    pub fn get_data_device(&self, seat: &wl_seat::WlSeat, qh: &QueueHandle<MutexBackendState>) -> DataControlDevice {
+    pub fn get_data_device(
+        &self,
+        seat: &wl_seat::WlSeat,
+        qh: &QueueHandle<MutexBackendState>,
+    ) -> DataControlDevice {
         match self {
             Self::Wlr(manager) => DataControlDevice::Wlr(manager.get_data_device(seat, qh, ())),
             Self::Ext(manager) => DataControlDevice::Ext(manager.get_data_device(seat, qh, ())),
@@ -76,9 +80,13 @@ impl DataControlDevice {
 
     pub fn set_selection(&self, source: Option<&DataControlSource>) {
         match (self, source) {
-            (Self::Wlr(device), Some(DataControlSource::Wlr(source))) => device.set_selection(Some(source)),
+            (Self::Wlr(device), Some(DataControlSource::Wlr(source))) => {
+                device.set_selection(Some(source))
+            }
             (Self::Wlr(device), None) => device.set_selection(None),
-            (Self::Ext(device), Some(DataControlSource::Ext(source))) => device.set_selection(Some(source)),
+            (Self::Ext(device), Some(DataControlSource::Ext(source))) => {
+                device.set_selection(Some(source))
+            }
             (Self::Ext(device), None) => device.set_selection(None),
             _ => warn!("Mismatched data control protocol between device and source"),
         }
@@ -113,14 +121,14 @@ pub struct BackendState {
     // Clipboard history and management
     pub history: Vec<ClipboardItem>,
     pub id_for_next_entry: u64,
-    
+
     // Wayland objects for clipboard operations
     pub data_control_manager: Option<DataControlManager>,
     pub data_control_device: Option<DataControlDevice>,
     pub qh: Option<QueueHandle<MutexBackendState>>,
     pub seat: Option<wl_seat::WlSeat>,
     pub connection: Option<Connection>,
-    
+
     // Current clipboard data
     // Mapping of offer ObjectId -> list of MIME types provided by that offer
     pub mime_type_offers: HashMap<ObjectId, Vec<String>>,
@@ -167,8 +175,13 @@ impl BackendState {
         }
     }
 
-    pub fn add_clipboard_item_from_mime_map(&mut self, mut mime_content: IndexMap<String, Bytes>) -> Option<u64> {
-        if mime_content.is_empty() { return None; }
+    pub fn add_clipboard_item_from_mime_map(
+        &mut self,
+        mut mime_content: IndexMap<String, Bytes>,
+    ) -> Option<u64> {
+        if mime_content.is_empty() {
+            return None;
+        }
 
         // If we have image/png, prefer showing mime_type + bytes and set type to Image
         let (content_preview, content_type, thumbnail) = if let Some(png_bytes) =
@@ -181,16 +194,21 @@ impl BackendState {
             )
         } else {
             // Otherwise, if we have text/plain;charset=utf-8, show up to first 200 chars and infer type
-            let preview: String = if let Some(txt_bytes) = mime_content.get("text/plain;charset=utf-8") {
-                match std::str::from_utf8(txt_bytes.as_ref()) {
-                    Ok(s) => s.chars().take(200).collect(),
-                    Err(_) => format!("<text/plain;charset=utf-8 {} bytes>", txt_bytes.len()),
-                }
-            } else {
-                // Fallback: show placeholder using first mime entry
-                let (mime_name, len) = mime_content.iter().next().map(|(k,v)| (k.clone(), v.len())).unwrap();
-                format!("<{mime_name} {len} bytes>")
-            };
+            let preview: String =
+                if let Some(txt_bytes) = mime_content.get("text/plain;charset=utf-8") {
+                    match std::str::from_utf8(txt_bytes.as_ref()) {
+                        Ok(s) => s.chars().take(200).collect(),
+                        Err(_) => format!("<text/plain;charset=utf-8 {} bytes>", txt_bytes.len()),
+                    }
+                } else {
+                    // Fallback: show placeholder using first mime entry
+                    let (mime_name, len) = mime_content
+                        .iter()
+                        .next()
+                        .map(|(k, v)| (k.clone(), v.len()))
+                        .unwrap();
+                    format!("<{mime_name} {len} bytes>")
+                };
             let content_type = ClipboardContentType::type_from_preview(&preview);
             (preview, content_type, None)
         };
@@ -199,21 +217,27 @@ impl BackendState {
             item_id: self.id_for_next_entry,
             content_type,
             content_preview,
-            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
             pinned: false,
             mime_data: mime_content.drain(..).collect(),
             thumbnail,
         };
 
         // remove duplicates (todo change to more robust solution -> hashes)
-        self.history.retain(|existing| existing.content_preview != item.content_preview);
+        self.history
+            .retain(|existing| existing.content_preview != item.content_preview);
         let insert_index = self
             .history
             .iter()
             .position(|existing| !existing.pinned)
             .unwrap_or(self.history.len());
         self.history.insert(insert_index, item);
-        if self.history.len() > 100 { self.history.truncate(100); }
+        if self.history.len() > 100 {
+            self.history.truncate(100);
+        }
         let new_id = self.id_for_next_entry;
         self.id_for_next_entry += 1;
         Some(new_id)
@@ -229,7 +253,8 @@ impl BackendState {
 
         let max_width = 300u32;
         let max_height = 180u32;
-        let scale = (max_width as f32 / src_width as f32).min(max_height as f32 / src_height as f32);
+        let scale =
+            (max_width as f32 / src_width as f32).min(max_height as f32 / src_height as f32);
         let dst_width = ((src_width as f32 * scale).round() as u32).max(1);
         let dst_height = ((src_height as f32 * scale).round() as u32).max(1);
 
@@ -243,17 +268,15 @@ impl BackendState {
 
         let mut dst_image = Image::new(dst_width, dst_height, fir::PixelType::U8x4);
         let mut resizer = fir::Resizer::new();
-        let options = fir::ResizeOptions::new().resize_alg(fir::ResizeAlg::Convolution(
-            fir::FilterType::Bilinear,
-        ));
+        let options = fir::ResizeOptions::new()
+            .resize_alg(fir::ResizeAlg::Convolution(fir::FilterType::Bilinear));
 
-        resizer.resize(&src_image, &mut dst_image, Some(&options)).ok()?;
+        resizer
+            .resize(&src_image, &mut dst_image, Some(&options))
+            .ok()?;
 
-        let thumbnail = RgbaImage::from_raw(
-            dst_image.width(),
-            dst_image.height(),
-            dst_image.into_vec(),
-        )?;
+        let thumbnail =
+            RgbaImage::from_raw(dst_image.width(), dst_image.height(), dst_image.into_vec())?;
 
         let mut buffer = Cursor::new(Vec::new());
         if image::DynamicImage::ImageRgba8(thumbnail)
@@ -276,16 +299,19 @@ impl BackendState {
         self.add_clipboard_item_from_mime_map(mime_content)
     }
 
-    pub fn get_history(&self) -> Vec<ClipboardItemPreview> { 
-    self.history.iter().map(ClipboardItemPreview::from).collect()
+    pub fn get_history(&self) -> Vec<ClipboardItemPreview> {
+        self.history
+            .iter()
+            .map(ClipboardItemPreview::from)
+            .collect()
     }
-    
-    pub fn get_item_by_id(&self, id: u64) -> Option<ClipboardItem> { 
-        self.history.iter().find(|i| i.item_id == id).cloned() 
+
+    pub fn get_item_by_id(&self, id: u64) -> Option<ClipboardItem> {
+        self.history.iter().find(|i| i.item_id == id).cloned()
     }
-    
-    pub fn clear_history(&mut self) { 
-        self.history.clear(); 
+
+    pub fn clear_history(&mut self) {
+        self.history.clear();
     }
 
     pub fn delete_item_by_id(&mut self, entry_id: u64) -> Result<(), String> {
@@ -308,10 +334,15 @@ impl BackendState {
     }
 
     pub fn set_clipboard_by_id(&mut self, entry_id: u64) -> Result<(), String> {
-        let item = self.get_item_by_id(entry_id).ok_or_else(|| format!("No clipboard item found with ID: {entry_id}"))?;
-        
+        let item = self
+            .get_item_by_id(entry_id)
+            .ok_or_else(|| format!("No clipboard item found with ID: {entry_id}"))?;
+
         info!("Setting clipboard content by ID {entry_id}");
-        debug!("Setting clipboard content by ID {entry_id}: {}", item.content_preview);
+        debug!(
+            "Setting clipboard content by ID {entry_id}: {}",
+            item.content_preview
+        );
 
         let (Some(manager), Some(device), Some(qh)) = (
             &self.data_control_manager,
@@ -327,7 +358,9 @@ impl BackendState {
         }
 
         let source = manager.create_data_source(qh);
-        for (mime, _data) in &item.mime_data { source.offer(mime.clone()); }
+        for (mime, _data) in &item.mime_data {
+            source.offer(mime.clone());
+        }
         device.set_selection(Some(&source));
         self.current_source_object = Some(source);
         self.current_source_entry_id = Some(entry_id);
@@ -335,7 +368,8 @@ impl BackendState {
         self.suppress_next_selection_read = true;
         // Flush the Wayland connection so the compositor sees our selection (very important)
         if let Some(conn) = &self.connection
-            && let Err(e) = conn.flush() {
+            && let Err(e) = conn.flush()
+        {
             warn!("Failed to flush Wayland connection after setting selection: {e}");
         }
         debug!("Created clipboard source and set selection (id {entry_id})");

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,5 +1,5 @@
-pub mod ipc_server;
 pub mod backend_state;
+pub mod ipc_server;
 pub mod wayland_clipboard;
 
 pub use ipc_server::*;

--- a/src/backend/wayland_clipboard.rs
+++ b/src/backend/wayland_clipboard.rs
@@ -1,8 +1,10 @@
+use crate::backend::backend_state::{BackendState, DataControlManager};
+use std::sync::Arc as StdArc; // for event_created_child return type clarity
 use std::sync::{Arc, Mutex};
+use wayland_client::globals::{GlobalList, GlobalListContents, registry_queue_init};
+use wayland_client::protocol::wl_registry;
 use wayland_client::protocol::wl_seat::WlSeat;
-use wayland_client::{delegate_noop, Connection, Dispatch, EventQueue, Proxy, QueueHandle};
-use wayland_client::globals::{GlobalList, registry_queue_init, GlobalListContents};
-use wayland_client::protocol::{wl_registry};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop};
 use wayland_protocols::ext::data_control::v1::client::{
     ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
     ext_data_control_manager_v1::ExtDataControlManagerV1,
@@ -10,17 +12,15 @@ use wayland_protocols::ext::data_control::v1::client::{
     ext_data_control_source_v1::{self, ExtDataControlSourceV1},
 };
 use wayland_protocols_wlr::data_control::v1::client::{
-    zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
     zwlr_data_control_device_v1::{self, ZwlrDataControlDeviceV1},
+    zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
     zwlr_data_control_offer_v1::{self, ZwlrDataControlOfferV1},
     zwlr_data_control_source_v1::{self, ZwlrDataControlSourceV1},
 };
-use std::sync::Arc as StdArc; // for event_created_child return type clarity
-use crate::backend::backend_state::{BackendState, DataControlManager};
 
-use indexmap::IndexMap;
 use bytes::Bytes;
-use log::{info, debug, warn, error};
+use indexmap::IndexMap;
+use log::{debug, error, info, warn};
 
 // Wrapper struct that holds the shared backend state for dispatch implementations
 pub struct MutexBackendState {
@@ -45,7 +45,9 @@ impl WaylandClipboardMonitor {
                 .map_err(|e| format!("Failed to init registry: {e}"))?;
 
         // Create wrapper for shared state
-        let mut shared_state_wrapper = MutexBackendState { backend_state: self.backend_state.clone() };
+        let mut shared_state_wrapper = MutexBackendState {
+            backend_state: self.backend_state.clone(),
+        };
 
         // Bind required globals
         let qh = event_queue.handle();
@@ -57,7 +59,9 @@ impl WaylandClipboardMonitor {
         }
 
         // Bind seat
-        if let Ok(seat) = globals.bind::<wayland_client::protocol::wl_seat::WlSeat, _, _>(&qh, 1..=9, ()) {
+        if let Ok(seat) =
+            globals.bind::<wayland_client::protocol::wl_seat::WlSeat, _, _>(&qh, 1..=9, ())
+        {
             let mut state = self.backend_state.lock().unwrap();
             state.seat = Some(seat);
         } else {
@@ -74,7 +78,9 @@ impl WaylandClipboardMonitor {
         if let Ok(manager) = globals.bind::<ExtDataControlManagerV1, _, _>(&qh, 1..=1, ()) {
             let mut state = self.backend_state.lock().unwrap();
             state.data_control_manager = Some(DataControlManager::Ext(manager));
-            if let (Some(data_control_manager), Some(seat)) = (&state.data_control_manager, &state.seat) {
+            if let (Some(data_control_manager), Some(seat)) =
+                (&state.data_control_manager, &state.seat)
+            {
                 let device = data_control_manager.get_data_device(seat, &qh);
                 state.data_control_device = Some(device);
             }
@@ -82,7 +88,9 @@ impl WaylandClipboardMonitor {
         } else if let Ok(manager) = globals.bind::<ZwlrDataControlManagerV1, _, _>(&qh, 2..=2, ()) {
             let mut state = self.backend_state.lock().unwrap();
             state.data_control_manager = Some(DataControlManager::Wlr(manager));
-            if let (Some(data_control_manager), Some(seat)) = (&state.data_control_manager, &state.seat) {
+            if let (Some(data_control_manager), Some(seat)) =
+                (&state.data_control_manager, &state.seat)
+            {
                 let device = data_control_manager.get_data_device(seat, &qh);
                 state.data_control_device = Some(device);
             }
@@ -99,7 +107,8 @@ impl WaylandClipboardMonitor {
 
         loop {
             // Dispatch pending events, then block waiting for new ones
-            event_queue.blocking_dispatch(&mut shared_state_wrapper)
+            event_queue
+                .blocking_dispatch(&mut shared_state_wrapper)
                 .map_err(|e| format!("Failed to dispatch events: {e}"))?;
         }
     }
@@ -137,7 +146,7 @@ impl Dispatch<ZwlrDataControlDeviceV1, ()> for MutexBackendState {
         _qh: &QueueHandle<Self>,
     ) {
         let mut state = wrapper.backend_state.lock().unwrap();
-        
+
         match event {
             zwlr_data_control_device_v1::Event::DataOffer { id } => {
                 let object_id = id.id();
@@ -150,17 +159,28 @@ impl Dispatch<ZwlrDataControlDeviceV1, ()> for MutexBackendState {
                     debug!("Selection changed to offer ID: {offer_key:?}");
 
                     let (mime_list, already_current, suppress_read) = {
-                        let already_current =
-                            state.current_data_offer.as_ref().is_some_and(|o| o == &offer_key);
+                        let already_current = state
+                            .current_data_offer
+                            .as_ref()
+                            .is_some_and(|o| o == &offer_key);
                         let mime_list = state.mime_type_offers.get(&offer_key).cloned();
-                        (mime_list, already_current, state.suppress_next_selection_read)
+                        (
+                            mime_list,
+                            already_current,
+                            state.suppress_next_selection_read,
+                        )
                     };
 
                     if let Some(mime_list) = mime_list {
-                        debug!("New clipboard content available with {} MIME types", mime_list.len());
+                        debug!(
+                            "New clipboard content available with {} MIME types",
+                            mime_list.len()
+                        );
                         if suppress_read {
                             state.current_data_offer = Some(offer_key);
-                            debug!("Suppressed reading our own just-set selection; waiting for Cancelled to re-enable reads");
+                            debug!(
+                                "Suppressed reading our own just-set selection; waiting for Cancelled to re-enable reads"
+                            );
                             offer_id.destroy();
                             return;
                         }
@@ -180,7 +200,8 @@ impl Dispatch<ZwlrDataControlDeviceV1, ()> for MutexBackendState {
                             let mut state = wrapper.backend_state.lock().unwrap();
                             if let Some(new_id) = state.add_clipboard_item_from_mime_map(mime_map)
                                 && !state.monitor_only
-                                && !state.suppress_next_selection_read {
+                                && !state.suppress_next_selection_read
+                            {
                                 if let Err(e) = state.set_clipboard_by_id(new_id) {
                                     warn!("Failed to take ownership of selection id {new_id}: {e}");
                                 } else {
@@ -230,7 +251,8 @@ impl Dispatch<ZwlrDataControlOfferV1, ()> for MutexBackendState {
             debug!("Offer event: MIME type offered: {mime_type}");
             let mut state = wrapper.backend_state.lock().unwrap();
             if let Some(mime_list) = state.mime_type_offers.get_mut(&object_id)
-                && !mime_type.starts_with("video") {
+                && !mime_type.starts_with("video")
+            {
                 mime_list.push(mime_type);
             }
         }
@@ -247,7 +269,7 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for MutexBackendState {
         _: &QueueHandle<Self>,
     ) {
         let mut state = wrapper.backend_state.lock().unwrap();
-        
+
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type, fd } => {
                 debug!("Data source Send event for MIME type: {mime_type}");
@@ -261,10 +283,15 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for MutexBackendState {
                                     "Failed writing selection data (id {item_id}, mime {mime_type}): {e}",
                                 );
                             } else {
-                                debug!("Wrote {} bytes for id {item_id} (mime {mime_type})", bytes.len());
+                                debug!(
+                                    "Wrote {} bytes for id {item_id} (mime {mime_type})",
+                                    bytes.len()
+                                );
                             }
                         } else {
-                            warn!("No data stored for MIME {mime_type} (id {item_id}), nothing written");
+                            warn!(
+                                "No data stored for MIME {mime_type} (id {item_id}), nothing written"
+                            );
                         }
                     } else {
                         warn!("Clipboard item id {item_id} no longer exists in history");
@@ -274,10 +301,18 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for MutexBackendState {
                 }
             }
             zwlr_data_control_source_v1::Event::Cancelled => {
-                debug!("Data source cancelled. Last offered content (object id {:?})", event_source.id());
-                //Re-enabled reading new selections if currently active selection is cancelled, therefore external client took over 
+                debug!(
+                    "Data source cancelled. Last offered content (object id {:?})",
+                    event_source.id()
+                );
+                //Re-enabled reading new selections if currently active selection is cancelled, therefore external client took over
                 //if the cancelled event is not for the currently active selection, it was our previous selection -> new entry chosen within clipboard manager
-                if state.current_source_object.as_ref().map(|source| source.id()) == Some(event_source.id()) {
+                if state
+                    .current_source_object
+                    .as_ref()
+                    .map(|source| source.id())
+                    == Some(event_source.id())
+                {
                     state.suppress_next_selection_read = false;
                     state.current_source_object = None;
                     debug!("Re-enabled selection reading (external client took over)");
@@ -313,17 +348,28 @@ impl Dispatch<ExtDataControlDeviceV1, ()> for MutexBackendState {
                     debug!("Selection changed to offer ID: {offer_key:?}");
 
                     let (mime_list, already_current, suppress_read) = {
-                        let already_current =
-                            state.current_data_offer.as_ref().is_some_and(|o| o == &offer_key);
+                        let already_current = state
+                            .current_data_offer
+                            .as_ref()
+                            .is_some_and(|o| o == &offer_key);
                         let mime_list = state.mime_type_offers.get(&offer_key).cloned();
-                        (mime_list, already_current, state.suppress_next_selection_read)
+                        (
+                            mime_list,
+                            already_current,
+                            state.suppress_next_selection_read,
+                        )
                     };
 
                     if let Some(mime_list) = mime_list {
-                        debug!("New clipboard content available with {} MIME types", mime_list.len());
+                        debug!(
+                            "New clipboard content available with {} MIME types",
+                            mime_list.len()
+                        );
                         if suppress_read {
                             state.current_data_offer = Some(offer_key);
-                            debug!("Suppressed reading our own just-set selection; waiting for Cancelled to re-enable reads");
+                            debug!(
+                                "Suppressed reading our own just-set selection; waiting for Cancelled to re-enable reads"
+                            );
                             offer_id.destroy();
                             return;
                         }
@@ -342,7 +388,8 @@ impl Dispatch<ExtDataControlDeviceV1, ()> for MutexBackendState {
                             let mut state = wrapper.backend_state.lock().unwrap();
                             if let Some(new_id) = state.add_clipboard_item_from_mime_map(mime_map)
                                 && !state.monitor_only
-                                && !state.suppress_next_selection_read {
+                                && !state.suppress_next_selection_read
+                            {
                                 if let Err(e) = state.set_clipboard_by_id(new_id) {
                                     warn!("Failed to take ownership of selection id {new_id}: {e}");
                                 } else {
@@ -389,7 +436,8 @@ impl Dispatch<ExtDataControlOfferV1, ()> for MutexBackendState {
             debug!("Offer event: MIME type offered: {mime_type}");
             let mut state = wrapper.backend_state.lock().unwrap();
             if let Some(mime_list) = state.mime_type_offers.get_mut(&object_id)
-                && !mime_type.starts_with("video") {
+                && !mime_type.starts_with("video")
+            {
                 mime_list.push(mime_type);
             }
         }
@@ -420,10 +468,15 @@ impl Dispatch<ExtDataControlSourceV1, ()> for MutexBackendState {
                                     "Failed writing selection data (id {item_id}, mime {mime_type}): {e}",
                                 );
                             } else {
-                                debug!("Wrote {} bytes for id {item_id} (mime {mime_type})", bytes.len());
+                                debug!(
+                                    "Wrote {} bytes for id {item_id} (mime {mime_type})",
+                                    bytes.len()
+                                );
                             }
                         } else {
-                            warn!("No data stored for MIME {mime_type} (id {item_id}), nothing written");
+                            warn!(
+                                "No data stored for MIME {mime_type} (id {item_id}), nothing written"
+                            );
                         }
                     } else {
                         warn!("Clipboard item id {item_id} no longer exists in history");
@@ -433,8 +486,16 @@ impl Dispatch<ExtDataControlSourceV1, ()> for MutexBackendState {
                 }
             }
             ext_data_control_source_v1::Event::Cancelled => {
-                debug!("Data source cancelled. Last offered content (object id {:?})", event_source.id());
-                if state.current_source_object.as_ref().map(|source| source.id()) == Some(event_source.id()) {
+                debug!(
+                    "Data source cancelled. Last offered content (object id {:?})",
+                    event_source.id()
+                );
+                if state
+                    .current_source_object
+                    .as_ref()
+                    .map(|source| source.id())
+                    == Some(event_source.id())
+                {
                     state.suppress_next_selection_read = false;
                     state.current_source_object = None;
                     debug!("Re-enabled selection reading (external client took over)");
@@ -469,7 +530,8 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for MutexBackendState
 // ================= Helper functions =================
 
 /// Create a pipe for reading clipboard data, returning `OwnedFd` handles.
-fn create_pipes() -> Result<(std::os::fd::OwnedFd, std::os::fd::OwnedFd), Box<dyn std::error::Error>> {
+fn create_pipes() -> Result<(std::os::fd::OwnedFd, std::os::fd::OwnedFd), Box<dyn std::error::Error>>
+{
     use std::os::fd::FromRawFd;
     let mut fds = [0; 2];
     if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
@@ -482,7 +544,9 @@ fn create_pipes() -> Result<(std::os::fd::OwnedFd, std::os::fd::OwnedFd), Box<dy
 
 /// Filters out mime types to speed up processing
 fn select_target_mimes(available_mimes: &[String]) -> Vec<String> {
-    let best_image_mime = available_mimes.iter().find(|m| *m == "image/png")
+    let best_image_mime = available_mimes
+        .iter()
+        .find(|m| *m == "image/png")
         .or_else(|| available_mimes.iter().find(|m| *m == "image/jpeg"))
         .or_else(|| available_mimes.iter().find(|m| *m == "image/bmp"));
 
@@ -497,9 +561,9 @@ fn read_all_data_formats_wlr(
     data_offer: &ZwlrDataControlOfferV1,
     mime_types: Vec<String>,
     conn: &Connection,
-)-> IndexMap<String, Bytes> {
-    use std::os::fd::AsFd;
+) -> IndexMap<String, Bytes> {
     use std::io::Read;
+    use std::os::fd::AsFd;
 
     let mut mime_map: IndexMap<String, Bytes> = IndexMap::new();
 
@@ -512,19 +576,26 @@ fn read_all_data_formats_wlr(
     for mime in targets {
         let (reader_fd, writer_fd) = match create_pipes() {
             Ok(pair) => pair,
-            Err(err) => { warn!("Could not open pipe to read data for {mime}: {err:?}"); continue; }
+            Err(err) => {
+                warn!("Could not open pipe to read data for {mime}: {err:?}");
+                continue;
+            }
         };
         debug!("Requesting {mime} content...");
         data_offer.receive(mime.clone(), writer_fd.as_fd());
         // Drop writer side so the provider gets EOF after writing
         drop(writer_fd);
-        if let Err(e) = conn.flush() { warn!("Flush failed: {e}"); }
+        if let Err(e) = conn.flush() {
+            warn!("Flush failed: {e}");
+        }
         // Convert OwnedFd to File for reading
         let mut reader_file = std::fs::File::from(reader_fd);
         let mut buf = Vec::new();
         match reader_file.read_to_end(&mut buf) {
             Ok(_) => {
-                if !buf.is_empty() { mime_map.insert(mime, Bytes::from(buf)); }
+                if !buf.is_empty() {
+                    mime_map.insert(mime, Bytes::from(buf));
+                }
             }
             Err(e) => warn!("Failed reading data for mime: {e}"),
         }
@@ -577,5 +648,3 @@ fn read_all_data_formats_ext(
 
     mime_map
 }
-
-

--- a/src/frontend/dispatch/empty_dispatch.rs
+++ b/src/frontend/dispatch/empty_dispatch.rs
@@ -4,28 +4,22 @@ use wayland_client::delegate_noop;
 
 // Core protocol objects
 use wayland_client::protocol::{
-    wl_compositor::WlCompositor,
-    wl_surface::WlSurface,
-    wl_region::WlRegion,
-    wl_buffer::WlBuffer,
-    wl_registry::WlRegistry,
-    wl_shm::WlShm,
-    wl_shm_pool::WlShmPool,
+    wl_buffer::WlBuffer, wl_compositor::WlCompositor, wl_region::WlRegion, wl_registry::WlRegistry,
+    wl_shm::WlShm, wl_shm_pool::WlShmPool, wl_surface::WlSurface,
 };
 
 // WLR layer shell
 use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;
 
 // Viewporter & single pixel buffer
-use wayland_protocols::wp::viewporter::client::{
-    wp_viewporter::WpViewporter,
-    wp_viewport::WpViewport,
-};
 use wayland_protocols::wp::single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1;
+use wayland_protocols::wp::viewporter::client::{
+    wp_viewport::WpViewport, wp_viewporter::WpViewporter,
+};
 
 // Generate the noop dispatch implementations
 delegate_noop!(State: WlCompositor);
-delegate_noop!(State: WlRegion);   
+delegate_noop!(State: WlRegion);
 delegate_noop!(State: WlSurface);
 delegate_noop!(State: ZwlrLayerShellV1);
 delegate_noop!(State: WpViewporter);
@@ -42,8 +36,8 @@ delegate_noop!(State: ignore WlShm);
 // Manual Dispatch implementations for specific interfaces needing custom logic
 //-------------------------------------------------------------------------------
 
-use wayland_client::{Connection, QueueHandle, Dispatch};
 use wayland_client::globals::GlobalListContents;
+use wayland_client::{Connection, Dispatch, QueueHandle};
 
 // WlRegistry needs a custom Dispatch due to custom UserData (GlobalListContents)
 impl Dispatch<WlRegistry, GlobalListContents> for State {
@@ -58,4 +52,3 @@ impl Dispatch<WlRegistry, GlobalListContents> for State {
         // No-op
     }
 }
-

--- a/src/frontend/dispatch/frame_callback.rs
+++ b/src/frontend/dispatch/frame_callback.rs
@@ -1,9 +1,9 @@
-use wayland_client::{Connection, Dispatch, QueueHandle};
 use wayland_client::protocol::wl_callback;
+use wayland_client::{Connection, Dispatch, QueueHandle};
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
-use crate::frontend::frontend_state::State;
 use crate::frontend::dispatch::layer_shell::cleanup_update_layer;
+use crate::frontend::frontend_state::State;
 use log::debug;
 
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ fn setup_update_layer(state: &mut State, qhandle: &QueueHandle<State>) {
         eprintln!("Layer shell not available");
         return;
     };
-    
+
     let Some(update_surface) = &state.update_surface else {
         eprintln!("Update surface not available");
         return;
@@ -88,9 +88,12 @@ fn setup_update_layer(state: &mut State, qhandle: &QueueHandle<State>) {
 fn schedule_next_frame_check(state: &mut State, qhandle: &QueueHandle<State>, frame_count: u8) {
     if let Some(update_surface) = &state.update_surface {
         debug!("Scheduling frame check #{}", frame_count + 1);
-        let frame_callback = update_surface.frame(qhandle, FrameCallbackData::UpdateLayerFrameCount(frame_count));
+        let frame_callback = update_surface.frame(
+            qhandle,
+            FrameCallbackData::UpdateLayerFrameCount(frame_count),
+        );
         state.update_frame_callback = Some(frame_callback);
-        
+
         // Commit to trigger the next frame
         update_surface.commit();
     } else {

--- a/src/frontend/dispatch/layer_shell.rs
+++ b/src/frontend/dispatch/layer_shell.rs
@@ -1,10 +1,8 @@
 use wayland_client::{Connection, Dispatch, QueueHandle};
-use wayland_protocols_wlr::layer_shell::v1::client::{
-    zwlr_layer_surface_v1,
-};
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1;
 
-use crate::frontend::frontend_state::State;
 use crate::frontend::dispatch::frame_callback::FrameCallbackData;
+use crate::frontend::frontend_state::State;
 use log::debug;
 
 impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for State {
@@ -27,7 +25,9 @@ impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for State {
 
                 // Check if this is the capture layer surface
                 if Some(layer_surface) == state.capture_layer_surface.as_ref() {
-                    let Some(capture_surface) = &state.capture_surface else { return; };
+                    let Some(capture_surface) = &state.capture_surface else {
+                        return;
+                    };
                     if let Some(buffer) = &state.transparent_buffer {
                         capture_surface.attach(Some(buffer), 0, 0);
                     }
@@ -46,7 +46,8 @@ impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for State {
                     if !state.capture_layer_ready {
                         state.capture_layer_ready = true;
                         debug!("Setting capture_layer_ready to true");
-                        let frame_callback = capture_surface.frame(qhandle, FrameCallbackData::CaptureLayer);
+                        let frame_callback =
+                            capture_surface.frame(qhandle, FrameCallbackData::CaptureLayer);
                         state.capture_frame_callback = Some(frame_callback);
                     }
                     capture_surface.commit();
@@ -54,7 +55,9 @@ impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for State {
 
                 // Check if this is the update layer surface
                 if Some(layer_surface) == state.update_layer_surface.as_ref() {
-                    let Some(update_surface) = &state.update_surface else { return; };
+                    let Some(update_surface) = &state.update_surface else {
+                        return;
+                    };
                     if let Some(buffer) = &state.transparent_buffer {
                         update_surface.attach(Some(buffer), 0, 0);
                     }
@@ -69,10 +72,11 @@ impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for State {
                         viewport.set_destination(width as i32, height as i32);
                     }
                     update_surface.damage(0, 0, width as i32, height as i32);
-                    
-                    let frame_callback = update_surface.frame(qhandle, FrameCallbackData::UpdateLayer);
+
+                    let frame_callback =
+                        update_surface.frame(qhandle, FrameCallbackData::UpdateLayer);
                     state.update_frame_callback = Some(frame_callback);
-                    
+
                     update_surface.commit();
                 }
             }

--- a/src/frontend/dispatch/mod.rs
+++ b/src/frontend/dispatch/mod.rs
@@ -1,4 +1,4 @@
+pub mod empty_dispatch;
 pub mod frame_callback;
 pub mod layer_shell;
 pub mod pointer;
-pub mod empty_dispatch;

--- a/src/frontend/dispatch/pointer.rs
+++ b/src/frontend/dispatch/pointer.rs
@@ -1,8 +1,8 @@
-use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
 use wayland_client::protocol::{wl_pointer, wl_seat};
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
 
 use crate::frontend::frontend_state::State;
-use log::{debug};
+use log::debug;
 
 impl Dispatch<wl_seat::WlSeat, ()> for State {
     fn event(
@@ -70,10 +70,11 @@ impl Dispatch<wl_pointer::WlPointer, ()> for State {
                 state: button_state,
             } => {
                 debug!("Pointer button {button:?} at time {time}: {button_state:?}");
-                
+
                 // Check for left mouse button click (button 272 = left click)
                 if button == 272
-                    && let WEnum::Value(wl_pointer::ButtonState::Pressed) = button_state {
+                    && let WEnum::Value(wl_pointer::ButtonState::Pressed) = button_state
+                {
                     debug!("Left mouse button clicked on capture layer - requesting close");
                     state.capture_layer_clicked = true; // future handling of outside click to close overlay
                 }

--- a/src/frontend/frontend_state.rs
+++ b/src/frontend/frontend_state.rs
@@ -1,17 +1,13 @@
+use std::fs::File;
 use wayland_client::protocol::{
     wl_buffer, wl_callback, wl_compositor, wl_pointer, wl_seat, wl_shm, wl_shm_pool, wl_surface,
 };
-use std::fs::File;
 
-use wayland_protocols_wlr::{
-    layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1},
-};
+use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
-use wayland_protocols::{
-    wp::{
-        single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1,
-        viewporter::client::{wp_viewporter, wp_viewport},
-    },
+use wayland_protocols::wp::{
+    single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1,
+    viewporter::client::{wp_viewport, wp_viewporter},
 };
 
 use crate::shared::ClipboardItemPreview;
@@ -21,7 +17,8 @@ pub struct State {
     pub layer_shell: Option<zwlr_layer_shell_v1::ZwlrLayerShellV1>,
     pub pointer: Option<wl_pointer::WlPointer>,
     pub seat: Option<wl_seat::WlSeat>,
-    pub single_pixel_buffer_manager: Option<wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1>,
+    pub single_pixel_buffer_manager:
+        Option<wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1>,
     pub viewporter: Option<wp_viewporter::WpViewporter>,
     pub shm: Option<wl_shm::WlShm>,
     pub shm_pool: Option<wl_shm_pool::WlShmPool>,

--- a/src/frontend/ipc_client.rs
+++ b/src/frontend/ipc_client.rs
@@ -1,6 +1,6 @@
-use std::os::unix::net::UnixStream;
+use crate::shared::{BackendMessage, ClipboardItemPreview, FrontendMessage};
 use std::io::{BufRead, BufReader, Write};
-use crate::shared::{FrontendMessage, BackendMessage, ClipboardItemPreview};
+use std::os::unix::net::UnixStream;
 
 const SOCKET_PATH: &str = "/tmp/cursor-clip.sock";
 
@@ -17,7 +17,10 @@ impl FrontendClient {
     }
 
     /// Send a message and get response
-    pub fn send_message(&mut self, message: FrontendMessage) -> Result<BackendMessage, Box<dyn std::error::Error>> {
+    pub fn send_message(
+        &mut self,
+        message: FrontendMessage,
+    ) -> Result<BackendMessage, Box<dyn std::error::Error>> {
         let message_json = serde_json::to_string(&message)?;
         self.stream.write_all(message_json.as_bytes())?;
         self.stream.write_all(b"\n")?;
@@ -25,14 +28,14 @@ impl FrontendClient {
         let mut reader = BufReader::new(&self.stream);
         let mut line = String::new();
         reader.read_line(&mut line)?;
-        
-    let response: BackendMessage = serde_json::from_str(line.trim())?;
+
+        let response: BackendMessage = serde_json::from_str(line.trim())?;
         Ok(response)
     }
 
     /// Get clipboard history
     pub fn get_history(&mut self) -> Result<Vec<ClipboardItemPreview>, Box<dyn std::error::Error>> {
-    let response = self.send_message(FrontendMessage::GetHistory)?;
+        let response = self.send_message(FrontendMessage::GetHistory)?;
         match response {
             BackendMessage::History { items } => Ok(items),
             BackendMessage::Error { message } => Err(message.into()),
@@ -40,9 +43,9 @@ impl FrontendClient {
         }
     }
 
-    /// Set clipboard by ID 
+    /// Set clipboard by ID
     pub fn set_clipboard_by_id(&mut self, id: u64) -> Result<(), Box<dyn std::error::Error>> {
-    let response = self.send_message(FrontendMessage::SetClipboardById { id })?;
+        let response = self.send_message(FrontendMessage::SetClipboardById { id })?;
         match response {
             BackendMessage::ClipboardSet => Ok(()),
             BackendMessage::Error { message } => Err(message.into()),
@@ -52,7 +55,7 @@ impl FrontendClient {
 
     /// Set pinned state by ID
     pub fn set_pinned(&mut self, id: u64, pinned: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let response = self.send_message(FrontendMessage::SetPinned { id, pinned })?;
+        let response = self.send_message(FrontendMessage::SetPinned { id, pinned })?;
         match response {
             BackendMessage::ItemPinned { .. } => Ok(()),
             BackendMessage::Error { message } => Err(message.into()),
@@ -62,7 +65,7 @@ impl FrontendClient {
 
     /// Clear history
     pub fn clear_history(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-    let response = self.send_message(FrontendMessage::ClearHistory)?;
+        let response = self.send_message(FrontendMessage::ClearHistory)?;
         match response {
             BackendMessage::HistoryCleared => Ok(()),
             BackendMessage::Error { message } => Err(message.into()),
@@ -72,7 +75,7 @@ impl FrontendClient {
 
     /// Delete a single clipboard item by ID
     pub fn delete_item_by_id(&mut self, id: u64) -> Result<(), Box<dyn std::error::Error>> {
-    let response = self.send_message(FrontendMessage::DeleteItemById { id })?;
+        let response = self.send_message(FrontendMessage::DeleteItemById { id })?;
         match response {
             BackendMessage::ItemDeleted { .. } => Ok(()),
             BackendMessage::Error { message } => Err(message.into()),

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,7 +1,7 @@
-pub mod initializer;
-pub mod frontend_state;
 pub mod dispatch;
+pub mod frontend_state;
 pub mod gtk_overlay;
+pub mod initializer;
 pub mod ipc_client;
 
 pub use initializer::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Arg, Command};
-use log::{info, error};
+use log::{error, info};
 
 mod backend;
 mod frontend;


### PR DESCRIPTION
Thanks to the PR and Notice from @Tomakin , who informed me that KDE Plasma has now officially moved away from zwlr_data_control_manager_v1 in favor of ext_data_control_manager_v1, the clipboard manager now supports both protocols. This restores functionality under the newest versions of KDE Plasma 6 and future-proofs the Wayland protocol interactions. Also formats the codebase using rustfmt

Closes #14 